### PR TITLE
Regenerate thumbnails if the size changed

### DIFF
--- a/simplegallery/media.py
+++ b/simplegallery/media.py
@@ -80,20 +80,18 @@ def create_video_thumbnail(video_path, thumbnail_path, height):
     cv2.imwrite(thumbnail_path, thumbnail)
 
 
-def create_thumbnail(input_path, thumbnails_path, height):
+def create_thumbnail(input_path, thumbnail_path, height):
     """
     Creates a thumbnail for a media file (image or video)
     :param input_path: input media path (image or video)
-    :param thumbnails_path: path to the folder, where the thumbnail should be stored
+    :param thumbnail_path: path to the thumbnail file to be created
     :param height: height of the thumbnail in pixels
     """
     # Handle JPGs and GIFs
     if input_path.lower().endswith('.jpg') or input_path.lower().endswith('.jpeg') or input_path.lower().endswith('.gif'):
-        thumbnail_path = os.path.join(thumbnails_path, os.path.basename(input_path))
         create_image_thumbnail(input_path, thumbnail_path, height)
     # Handle MP4s
     elif input_path.lower().endswith('.mp4'):
-        thumbnail_path = os.path.join(thumbnails_path, os.path.basename(input_path)).replace('.mp4', '.jpg').replace('.MP4', '.jpg')
         create_video_thumbnail(input_path, thumbnail_path, height)
     else:
         raise spg_common.SPGException(f'Unsupported file type ({os.path.basename(input_path)})')

--- a/simplegallery/test/logic/variants/test_file_gallery_logic.py
+++ b/simplegallery/test/logic/variants/test_file_gallery_logic.py
@@ -37,6 +37,13 @@ class FileGalleryLogicTestCase(unittest.TestCase):
             file_gallery_logic.create_thumbnails(force=True)
             self.assertEqual((160, 160), spg_media.get_image_size(thumbnail_path))
 
+            # Check thumbnail regenerated after size changed
+            gallery_config['thumbnail_height'] = 320
+            file_gallery_logic = FilesGalleryLogic(gallery_config)
+
+            file_gallery_logic.create_thumbnails()
+            self.assertEqual((320, 320), spg_media.get_image_size(thumbnail_path))
+
     @mock.patch('builtins.input', side_effect=['', '', '', ''])
     def test_generate_images_data(self, input):
         with TempDirectory() as tempdir:


### PR DESCRIPTION
If the size of the thumbnails is changed in the `gallery.json`, the thumbnails will be generated again.

Resolves #53 