### PR TITLE
Fix thumbnail creation for GIFs

### DIFF
--- a/simplegallery/logic/variants/files_gallery_logic.py
+++ b/simplegallery/logic/variants/files_gallery_logic.py
@@ -15,6 +15,17 @@ def check_correct_thumbnail_size(thumbnail_path, expected_height):
     return expected_height == spg_media.get_image_size(thumbnail_path)[1]
 
 
+def get_thumbnail_name(thumbnails_path, photo_name):
+    """
+    Generates the full path to a thumbnail file
+    :param thumbnails_path: Path to the folders where the thumbnails will be stored
+    :param photo_name: Name of the original photo
+    :return: Full path to the thumbnail file
+    """
+    photo_name_without_extension = os.path.basename(photo_name).split('.')[0]
+    return os.path.join(thumbnails_path, photo_name_without_extension + '.jpg')
+
+
 class FilesGalleryLogic(BaseGalleryLogic):
     """
     Gallery logic for a gallery composed of photos and videos stored as local files.
@@ -36,8 +47,7 @@ class FilesGalleryLogic(BaseGalleryLogic):
 
         count_thumbnails_created = 0
         for photo in photos:
-            photo_name = os.path.basename(photo).split('.')[0]
-            thumbnail_path = os.path.join(thumbnails_path, photo_name + ".jpg")
+            thumbnail_path = get_thumbnail_name(thumbnails_path, photo)
 
             # Check if the thumbnail should be generated. This happens if one of the following applies:
             # - Forced by the user with -f
@@ -63,8 +73,8 @@ class FilesGalleryLogic(BaseGalleryLogic):
         # Get the required metadata for each image
         for image in images:
             photo_name = os.path.basename(image)
-            thumbnail_path = os.path.join(self.gallery_config['thumbnails_path'], photo_name)
 
+            thumbnail_path = get_thumbnail_name(self.gallery_config['thumbnails_path'], image)
             image_data = spg_media.get_metadata(image, thumbnail_path, self.gallery_config['public_path'])
 
             # Check if the image file has changed and only then use the new metadata. This allows changes that were made

--- a/simplegallery/media.py
+++ b/simplegallery/media.py
@@ -63,6 +63,10 @@ def create_image_thumbnail(image_path, thumbnail_path, height):
     thumbnail_size = get_thumbnail_size(image.size, height)
     image = image.resize(thumbnail_size, Image.ANTIALIAS)
 
+    # Convert to RGB if needed
+    if image.mode == "P":
+        image = image.convert('RGB')
+
     image.save(thumbnail_path)
     image.close()
 

--- a/simplegallery/test/helpers.py
+++ b/simplegallery/test/helpers.py
@@ -54,6 +54,12 @@ def create_mock_image(path, width, height):
     :param width: width of the image
     :param height: height of the image
     """
-    img = Image.new('RGB', (width, height), color='red')
+    if path.lower().endswith('.jpg') or path.lower().endswith('.jpeg'):
+        img = Image.new('RGB', (width, height), color='red')
+    elif path.lower().endswith('.gif'):
+        img = Image.new('P', (width, height), color='red')
+    else:
+        raise RuntimeError('Unsupported image type')
+
     img.save(path)
     img.close()

--- a/simplegallery/test/logic/variants/test_file_gallery_logic.py
+++ b/simplegallery/test/logic/variants/test_file_gallery_logic.py
@@ -13,8 +13,10 @@ class FileGalleryLogicTestCase(unittest.TestCase):
     def test_create_thumbnails(self, input):
         with TempDirectory() as tempdir:
             helpers.create_mock_image(os.path.join(tempdir.path, 'photo.jpg'), 1000, 500)
+            helpers.create_mock_image(os.path.join(tempdir.path, 'photo2.gif'), 1000, 500)
 
             thumbnail_path = os.path.join(tempdir.path, 'public', 'images', 'thumbnails', 'photo.jpg')
+            thumbnail_gif_path = os.path.join(tempdir.path, 'public', 'images', 'thumbnails', 'photo2.jpg')
 
             # Init files gallery logic
             gallery_config = helpers.init_gallery_and_read_gallery_config(tempdir.path)
@@ -25,8 +27,9 @@ class FileGalleryLogicTestCase(unittest.TestCase):
 
             # Check thumbnail created
             file_gallery_logic.create_thumbnails()
-            tempdir.compare(['.empty', 'photo.jpg'], path='public/images/thumbnails')
+            tempdir.compare(['.empty', 'photo.jpg', 'photo2.jpg'], path='public/images/thumbnails')
             self.assertEqual((320, 160), spg_media.get_image_size(thumbnail_path))
+            self.assertEqual((320, 160), spg_media.get_image_size(thumbnail_gif_path))
 
             # Check thumbnail not regenerated without force
             helpers.create_mock_image(os.path.join(tempdir.path, 'public', 'images', 'photos', 'photo.jpg'), 500, 500)


### PR DESCRIPTION
This PR fixes a bug that caused an exception when creating a thumbnail for a GIF file.