### PR TITLE
Add optional image date to the description

### DIFF
--- a/doc/GalleryConfiguration.md
+++ b/doc/GalleryConfiguration.md
@@ -11,7 +11,7 @@ The `gallery.json` file in the gallery root folder contains important settings f
 * `background_photo` - the file name of the photo that should be used as background image. Example: `"usa-170.jpg"`.
 * `background_photo_offset` - the vertical offset of the overview image in percentage. Use this to shift the portion of the overview image that is shown to focus on the most important pars. Example: `30`.
 * `url` - URL of the website where your gallery will be hosted. This information is only needed to enable better display when you share a link to your gallery on social media like Twitter or Facebook. Example: `"https://www.haltakov.net/gallery_usa_multi/CUPcTB5AcbutK3vyLQ26"`.
-
+* `date_format` - optional parameter if you want to display the date the image is taken in the caption. See [Photo Date](#photo-date) for more information. Disabled by default.
 
 ## Photo Captions
 
@@ -20,6 +20,20 @@ You can show a caption for each photo that is shown on the bottom of the image w
 1. **Image metadata**: some photo editors, like for example Adobe Lightroom, allow you to define a description for each image. It is written in the image metadata and the `gallery-build` can read it from there. It reads the `ImageDescription` EXIF tag. All captions are then stored in the `images_data.json` file.
 2. **Manually**: executing the `gallery-build` command will create a file called `images_data.json`. It contains some metadata for each photo and a property called `description` where you can enter the caption for each image.
 
+### Photo Date
+
+If you want to include the date the photo is take, you can do it by adding the `date_format` setting in `gallery.json`. The value of this setting determines the format of the date. The format is specified using the [Python `strftime` codes](https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior). See some examples for common use-cases below.
+
+| Format | Example |
+| --- | --- |
+| `"date_format": "%d.%m.%Y"` | 13.06.2020 |
+| `"date_format": "Date: %d.%m.%Y"` | Date: 13.06.2020 |
+| `"date_format": "Date: %m/%d/%Y"` | Date: 06/13/2020 |
+| `"date_format": "Date: %b %d %Y"` | Date: Jun 06 2020 |
+| `"date_format": "Date: %B %d %Y"` | Date: June 06 2020 |
+| `"date_format": "Photo date: %Y-%m-%d"` | Photo date: 2020-06-13 |
+
+Remember to run `gallery-build` after modifying `gallery.json`.
 
 ## Sections
 

--- a/simplegallery/data/public/css/main.css
+++ b/simplegallery/data/public/css/main.css
@@ -65,6 +65,13 @@ body {
   margin: 0px auto 20px;
 }
 
+.caption-date {
+  font-size: 15px;
+  font-weight: normal;
+  margin-top: 3px;
+  margin-bottom: 0px;
+}
+
 footer {
   margin-top: 30px;
 }

--- a/simplegallery/data/public/js/main.js
+++ b/simplegallery/data/public/js/main.js
@@ -3,10 +3,11 @@ var slides = {}
 function createSlides() {
   $("a.gallery-photo").each(function (photo_id, photo) {
     var slide = {
-      w:    photo.getAttribute('data-width'),
-      h:    photo.getAttribute('data-height'),
-      msrc: photo.getElementsByTagName('img')[0].getAttribute('src'),
+      w:     photo.getAttribute('data-width'),
+      h:     photo.getAttribute('data-height'),
+      msrc:  photo.getElementsByTagName('img')[0].getAttribute('src'),
       title: photo.getElementsByTagName('img')[0].getAttribute('alt'),
+      date:  photo.getAttribute('data-date'),
     };
 
     if (photo.getAttribute('data-type') == 'image')
@@ -30,6 +31,18 @@ function getThumbBounds(gallery, index) {
   return {x: rect.left, y: rect.top + pageYScroll, w: rect.width};
 }
 
+function addCaptionHTML(item, captionEl, isFake) {
+  if(!item.title && !item.date) {
+    captionEl.children[0].innerText = '';
+    return false;
+  }
+  captionEl.children[0].innerHTML = item.title;
+  if (item.date) {
+    captionEl.children[0].innerHTML += '<p class="caption-date">' + item.date + '</p>';
+  }
+  return true;
+}
+
 function openPhotoSwipe() {
   var index = parseInt($(this).attr('data-index'))
   var gallery_id = $(this).attr('data-gallery')
@@ -37,6 +50,7 @@ function openPhotoSwipe() {
   var options = {
     index: index,
     getThumbBoundsFn: function (id) { return getThumbBounds(gallery_id, id) },
+    addCaptionHTMLFn: addCaptionHTML,
     preload: [2,5],
     zoomEl: false,
     shareEl: true,

--- a/simplegallery/data/templates/gallery_macros.jinja
+++ b/simplegallery/data/templates/gallery_macros.jinja
@@ -9,6 +9,7 @@
          data-gallery="{{ from }}"
          data-width="{{ images[i].size[0] }}"
          data-height="{{ images[i].size[1] }}"
+         data-date="{{ images[i].date }}"
          style="--w: {{ images[i].thumbnail_size[0] }}; --h: {{ images[i].thumbnail_size[1] }}">
          <img src="{{ images[i].thumbnail }}" class="thumbnail rounded" alt="{{ images[i].description }}"/></a>
     {% endfor %}


### PR DESCRIPTION
This PR adds the possibility to add the date the photo was taken to the description. This feature is disabled by default, but can be enabled by an option in the `gallery.json`.

Resolves: #68 