### PR TITLE
Fix switched width height bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(current_folder, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='simple-photo-gallery',
-    version='1.3.0',
+    version='1.3.1',
     description='Pretty and simple HTML photo galleries you can host yourself.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/simplegallery/media.py
+++ b/simplegallery/media.py
@@ -18,21 +18,24 @@ def rotate_image_by_orientation(image):
     :return: Rotated image
     """
 
-    exif = image._getexif()
-    if exif and EXIF_TAG_MAP["Orientation"] in exif:
-        orientation = exif[EXIF_TAG_MAP["Orientation"]]
+    try:
+        exif = image._getexif()
+        if exif and EXIF_TAG_MAP["Orientation"] in exif:
+            orientation = exif[EXIF_TAG_MAP["Orientation"]]
 
-        if orientation == 3:
-            rotation_angle = 180
-        elif orientation == 6:
-            rotation_angle = 270
-        elif orientation == 8:
-            rotation_angle = 90
-        else:
-            rotation_angle = 0
+            if orientation == 3:
+                rotation_angle = 180
+            elif orientation == 6:
+                rotation_angle = 270
+            elif orientation == 8:
+                rotation_angle = 90
+            else:
+                rotation_angle = 0
 
-        if rotation_angle != 0:
-            return image.rotate(rotation_angle, expand=True)
+            if rotation_angle != 0:
+                return image.rotate(rotation_angle, expand=True)
+    except:
+        pass
 
     return image
 
@@ -132,6 +135,7 @@ def get_image_size(image_path):
     :return: tuple containing the width and the height of the image in pixels
     """
     image = Image.open(image_path)
+    image = rotate_image_by_orientation(image)
     size = image.size
     image.close()
 


### PR DESCRIPTION
The image is now rotated according to the `Orientation` in the EXIF data, before the width and height is retrieved. This fixes a bug for rotated photos.

Resolves: #85 