### PR TITLE
Add noreferrer to the "Created by" link

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(current_folder, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='simple-photo-gallery',
-    version='1.3.1',
+    version='1.3.2',
     description='Pretty and simple HTML photo galleries you can host yourself.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/simplegallery/data/templates/index_template.jinja
+++ b/simplegallery/data/templates/index_template.jinja
@@ -100,7 +100,7 @@
     {% if 'link' in remote_data %}
       <p>The images in this gallery are hosted in a <a href="{{ remote_data['link'] }}">{{ remote_data['text'] }}</a></p>
     {% endif %}
-    <p>Created by <a href="https://www.haltakov.net/simple-photo-gallery">Simple Photo Gallery</a></p>
+    <p>Created by <a noreferrer href="https://www.haltakov.net/simple-photo-gallery">Simple Photo Gallery</a></p>
   </footer>
 
   <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>


### PR DESCRIPTION
Add a noreferrer attribute to the "Created by" link in order to prevent the URL to be recorded in the analytics.