### PR TITLE
Add option to disable captions

### DIFF
--- a/doc/GalleryConfiguration.md
+++ b/doc/GalleryConfiguration.md
@@ -13,6 +13,7 @@ The `gallery.json` file in the gallery root folder contains important settings f
 * `thumbnail_height` - height of the generated thumbnails in pixels (default 160).
 * `url` - URL of the website where your gallery will be hosted. This information is only needed to enable better display when you share a link to your gallery on social media like Twitter or Facebook. Example: `"https://www.haltakov.net/gallery_usa_multi/CUPcTB5AcbutK3vyLQ26"`.
 * `date_format` - optional parameter if you want to display the date the image is taken in the caption. See [Photo Date](#photo-date) for more information. Disabled by default.
+* `disbale_captions` - optional parameter that you can set to `true` if you want to disable the photo captions entirely. Set to `false` by default.
 
 ## Photo Captions
 
@@ -20,6 +21,11 @@ You can show a caption for each photo that is shown on the bottom of the image w
 
 1. **Image metadata**: some photo editors, like for example Adobe Lightroom, allow you to define a description for each image. It is written in the image metadata and the `gallery-build` can read it from there. It reads the `ImageDescription` EXIF tag. All captions are then stored in the `images_data.json` file.
 2. **Manually**: executing the `gallery-build` command will create a file called `images_data.json`. It contains some metadata for each photo and a property called `description` where you can enter the caption for each image.
+
+You can disable the captions by adding the following like to your `gallery.json` file. This is useful if your photos have some metadata in the `ImageDescription` EXIF tag. 
+```
+"disbale_captions": true
+```
 
 ### Photo Date
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(current_folder, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='simple-photo-gallery',
-    version='1.3.3',
+    version='1.3.4',
     description='Pretty and simple HTML photo galleries you can host yourself.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/simplegallery/gallery_build.py
+++ b/simplegallery/gallery_build.py
@@ -51,6 +51,11 @@ def build_html(gallery_config):
 
     images_data_list = [images_data[image] for image in images_data.keys()]
 
+    # Remove descriptions if the corresponding option is enabled
+    if 'disbale_captions' in gallery_config and gallery_config['disbale_captions']:
+        for image in images_data:
+            images_data[image]['description'] = ''
+
     # Find the first photo for the background if no background photo specified
     background_photo = gallery_config["background_photo"]
     if not background_photo:


### PR DESCRIPTION
This PR adds an option to disable the image captions. 

It can be activated by adding the following line to the `gallery.json` file:
```
"disbale_captions": true
```

Closes #92  