### PR TITLE
Fix spelling of disable_captions

### DIFF
--- a/doc/GalleryConfiguration.md
+++ b/doc/GalleryConfiguration.md
@@ -24,7 +24,7 @@ You can show a caption for each photo that is shown on the bottom of the image w
 
 You can disable the captions by adding the following like to your `gallery.json` file. This is useful if your photos have some metadata in the `ImageDescription` EXIF tag. 
 ```
-"disbale_captions": true
+"disable_captions": true
 ```
 
 ### Photo Date

--- a/simplegallery/gallery_build.py
+++ b/simplegallery/gallery_build.py
@@ -50,7 +50,7 @@ def build_html(gallery_config):
         images_data = json.load(images_data_in, object_pairs_hook=OrderedDict)
 
     # Remove descriptions if the corresponding option is enabled
-    if 'disbale_captions' in gallery_config and gallery_config['disbale_captions']:
+    if 'disable_captions' in gallery_config and gallery_config['disable_captions']:
         for image in images_data:
             images_data[image]['description'] = ''
 

--- a/simplegallery/gallery_init.py
+++ b/simplegallery/gallery_init.py
@@ -175,7 +175,7 @@ def create_gallery_json(gallery_root, remote_link, use_defaults=False):
         background_photo="",
         url="",
         background_photo_offset=30,
-        disbale_captions=False,
+        disable_captions=False,
     )
 
     # Initialize remote gallery configuration


### PR DESCRIPTION
`disable_captions` configuration option was spelt as `disbale_captions`.

This PR replaces all four instances of `disbale` with `disable`.