### PR TITLE
Add image hash for files gallery to replace use of mtime

### DIFF
--- a/doc/GalleryConfiguration.md
+++ b/doc/GalleryConfiguration.md
@@ -14,6 +14,7 @@ The `gallery.json` file in the gallery root folder contains important settings f
 * `url` - URL of the website where your gallery will be hosted. This information is only needed to enable better display when you share a link to your gallery on social media like Twitter or Facebook. Example: `"https://www.haltakov.net/gallery_usa_multi/CUPcTB5AcbutK3vyLQ26"`.
 * `date_format` - optional parameter if you want to display the date the image is taken in the caption. See [Photo Date](#photo-date) for more information. Disabled by default.
 * `disable_captions` - optional parameter that you can set to `true` if you want to disable the photo captions entirely. Set to `false` by default.
+* `force_description_reuse` - will reuse existing image descriptions in the images_data.json file, even if the file hash or modification time does not match. Set to `false` by default.
 
 ## Photo Captions
 

--- a/simplegallery/gallery_init.py
+++ b/simplegallery/gallery_init.py
@@ -176,6 +176,7 @@ def create_gallery_json(gallery_root, remote_link, use_defaults=False):
         url="",
         background_photo_offset=30,
         disable_captions=False,
+        force_description_reuse=False,
     )
 
     # Initialize remote gallery configuration

--- a/simplegallery/logic/base_gallery_logic.py
+++ b/simplegallery/logic/base_gallery_logic.py
@@ -23,11 +23,13 @@ class BaseGalleryLogic:
         """
         pass
 
-    def generate_images_data(self, images_data):
+    def generate_images_data(self, images_data, reuse_descriptions=False):
         """
         Generate the metadata for each image
         :param images_data: Images data dictionary containing the existing metadata of the images and which will be
         updated by this function
+        :param reuse_descriptions: keep existing descriptions even if a file
+        change is detected
         :return updated images data dictionary
         """
         return images_data
@@ -37,6 +39,10 @@ class BaseGalleryLogic:
         Creates or updates the images_data.json file with metadata for each image (e.g. size, description and thumbnail)
         """
         images_data_path = self.gallery_config["images_data_file"]
+        if "force_description_reuse" in self.gallery_config:
+            reuse_descriptions = self.gallery_config["force_description_reuse"]
+        else:
+            reuse_descriptions = False
 
         # Load the existing file or create an empty dict
         if os.path.exists(images_data_path):
@@ -46,7 +52,7 @@ class BaseGalleryLogic:
             images_data = {}
 
         # Generate the images data
-        self.generate_images_data(images_data)
+        self.generate_images_data(images_data, reuse_descriptions)
 
         # Write the data to the JSON file
         with open(images_data_path, "w", encoding="utf-8") as images_out:

--- a/simplegallery/media.py
+++ b/simplegallery/media.py
@@ -1,4 +1,6 @@
 import os
+import sys
+import hashlib
 import cv2
 import requests
 from io import BytesIO
@@ -10,6 +12,22 @@ import simplegallery.common as spg_common
 # Mapping of the string representation if an Exif tag to its id
 EXIF_TAG_MAP = {ExifTags.TAGS[tag]: tag for tag in ExifTags.TAGS}
 
+def get_sha1(imagepath):
+    """
+    Compute SHA1 for an image file.
+
+    :param imagepath: path to image file
+    :return: hexdigest as a string
+    """
+    sha1 = hashlib.sha1()
+    with open(imagepath, 'rb') as imgfile:
+        while True:
+            imgdata = imgfile.read(65536)
+            if not imgdata:
+                break
+            sha1.update(imgdata)
+
+    return sha1.hexdigest()
 
 def rotate_image_by_orientation(image):
     """
@@ -233,6 +251,7 @@ def get_metadata(image, thumbnail_path, public_path):
         src=os.path.relpath(image, public_path),
         mtime=os.path.getmtime(image),
         date=get_image_date(image),
+        imghash=get_sha1(image),
     )
 
     if image.lower().endswith(".jpg") or image.lower().endswith(".jpeg"):


### PR DESCRIPTION
This is a partial solution to #117. I implemented this for the files gallery but not the other variants. This is for your consideration.

* a sha1 hash is generated for each image and saved in the image_data file
* if hash is present in image_data file then that is used to detect file change
* if hash is not present in image_data file (older version), then the mtime is used to detect file change (old behavior). this should allow it to remain backward compatible with previously generated image_data files
* a new configuration item `force_description_reuse` is added that if true, will reuse descriptions even if it appears the file has changed. this can be used in situations like mine where I want to preserve descriptions for photos where the mtime changed for some reason but the file contents are the same

I did limited testing with my own test case.

I tried running the unit tests. As far as I can tell they all passed but I am not sure I ran them all, or ran them correctly.