### PR TITLE
Patch up problems with recent selenium version

### DIFF
--- a/examples/test_gallery/Makefile
+++ b/examples/test_gallery/Makefile
@@ -71,7 +71,13 @@
 # and it can uncover problems when dependencies are updated that introduce
 # breakages.
 
+# temp dir where source files and generated site will be located. it can be
+# safely deleted
 TESTDIR=output
+
+# port for local serving the static site. using 8008 because 8000 gets a little
+# overcrowded on my system
+SERVER_PORT=8008
 
 all: help
 
@@ -83,11 +89,14 @@ help:
 	@echo ""
 	@echo "testinit    - test creation of gallery from files (gallery-init)"
 	@echo "testinitrem - test init of gallery from remote album (goog or onedrive)"
-	@echo "              (need to set SPG_REMOTE) variable"
+	@echo "              (need to set SPG_REMOTE variable)"
 	@echo "              (current setting SPG_REMOTE=$(SPG_REMOTE))"
 	@echo "testbuild   - test build of gallery (gallery-build)"
 	@echo "testaws     - test upload to aws (gallery-upload aws)"
+	@echo "              (need to set SPG_AWS_BUCKET)"
+	@echo "              (current setting SPG_AWS_BUCKET=$(SPG_AWS_BUCKET))"
 	@echo "clean       - clean generated files"
+	@echo "serve       - run local python web server for static site"
 	@echo ""
 	@echo "venv        - create python virtual environment (automatic when needed)"
 	@echo "cleanvenv   - clean the python venv"
@@ -112,7 +121,7 @@ testbuild: $(TESTDIR)/public/index.html
 
 .PHONY: testaws
 testaws:
-	. venv/bin/activate; cd $(TESTDIR); gallery-upload aws s3://spg-gallery-test
+	. venv/bin/activate; cd $(TESTDIR); gallery-upload aws $(SPG_AWS_BUCKET)
 
 $(TESTDIR)/public/index.html:
 	. venv/bin/activate; cd $(TESTDIR); gallery-build
@@ -120,6 +129,10 @@ $(TESTDIR)/public/index.html:
 .PHONY: clean
 clean:
 	rm -rf $(TESTDIR)
+
+.PHONY: serve
+serve: venv
+	venv/bin/python -m http.server -d $(TESTDIR)/public $(SERVER_PORT)
 
 venv: venv/bin/activate
 

--- a/examples/test_gallery/README.md
+++ b/examples/test_gallery/README.md
@@ -1,7 +1,7 @@
 # Developer Gallery for Testing
 
 This area is used to help with testing and not intended for end users. The
-test gallery has 3 images from Library of Congress "free to use" maritime
+test gallery has several images from Library of Congress "free to use" maritime
 collection and are believed to be unencumbered. The images came from here:
 
 https://www.loc.gov/free-to-use/maritime-life/
@@ -9,22 +9,178 @@ https://www.loc.gov/free-to-use/maritime-life/
 They are relatively small file size to avoid adding large binaries to the repo.
 Over time more photos may be added as additional test cases.
 
-## Test overview
+This document contains test procedures and information to help with testing
+SPG. Things can change especially with online services so if you find an error
+in this document, please open an issue so we can keep this section up to date.
 
-There is a Makefile to help with performing tests in a repeatable way. See
-comments in the Makefile for more details about how to use it. It provides
-targets for init-ing, building, and uploading the gallery in different ways.
-The Makefile has a help target with some brief help:
+**TOC**
+
+* [Test Procedures](#test-procedures)
+    * [Test System Requirements](#test-system-requirements)
+    * [Files Gallery](#files-gallery)
+    * [Google Photos](#google-photos)
+    * [OneDrive Photos](#onedrive-photos)
+    * [AWS S3 Upload](#aws-s3-upload)
+    * [Netlify Upload](#netlify-upload)
+* [Test Setups](#test-setups)
+    * [Files Setup](#files-setup)
+    * [AWS Setup](#aws-setup)
+    * [Netlify Setup](#netlify-setup)
+    * [Google Setup](#google-setup)
+    * [OneDrive Setup](#onedrive-setup)
+* [TODOs](#todos)
+
+## Test Procedures
+
+The following test procedures are all done manually using a makefile and some
+scripts. It would be good for this eventually be integrated into CI for at
+least some level of automation.
+
+The test procedures utilize a test gallery with some sample images. Python3
+virtual environment (venv) is used to always create a clean and reproducible
+python environment.
+
+When the venv is created, the current SPG package is installed from source from
+the working tree. It is not installed in editable mode so if you make a change
+to the source, you need to clean the venv and recreate it. A possible future
+change could be to use editable mode instead or create a test option that does.
+
+Using the `venv` also insures that the latest packages from PyPI or whatever is
+constrained by the SPG package setup gets installed, and not using whatever
+stale versions of packages are on your system. It also makes it easier to catch
+breakages due to deprecations and changes in dependent packages.
+
+All of the tests are started from the test directory `examples/test_gallery`.
+There is a Makefile there with a little help:
 
     make help
 
-## Special setups
+Make sure you do not already have a python virtual environment activated when
+you start a test.
+
+All of the test procedures assume you are starting at the SPG top level and
+perform the following steps:
+
+    git switch (branch-being-tested)
+    cd examples/test_gallery
+    make clean
+    make cleanvenv
+    make venv
+    ...
+
+The branch is whatever branch you want to test and might be master. The clean
+steps insure you are starting with everything clean and a predictable
+environment. If you are debugging or trying different things it may not be
+necessary to clean each time, its up to you.
+
+### Test System Requirements
+
+The following command line tools are needed to run these tests:
+
+* GNU make (or something that can read GNU makefiles)
+* expect
+* python3 including venv
+* bash-like shell (Makefile has some small shell scripts)
+* git (if you want to be switching to test branches, etc)
+
+Please create a github issue if there is something I left off the list.
+
+### Files Gallery
+
+The files gallery means that the source of photos are in the local file system
+and a static site is generated into the local file system. This is the simplest
+situation as it requires no uploads or downloads from third party services.
+
+    git switch (branch-being-tested)        # optional as needed
+    cd examples/test_gallery
+    make clean
+    make cleanvenv
+    make venv
+    make testinit
+    make testbuild
+
+At this point the static site should be built and present at
+`output/public/index.html`. You can open this in a browser using `file://` url
+to verify the site looks correct. Or you can serve it on `localhost:8008` with
+`make serve`.
+
+### Google Photos
+
+This mode builds a static photos site using an album from Google photos as
+the source, instead of photos on the local file system. Prior to running this
+test you should have set up a Google photo albumm with some test photos and
+set it to viewable with URL.
+
+You will need to set an environment variable with the remote URL. A google
+remote URL looks like `https://photos.app.goo.gl/n7QTjrKLHruk` (that is a fake
+example).
+
+    git switch (branch-being-tested)        # optional as needed
+    cd examples/test_gallery
+    make clean
+    make cleanvenv
+    export SPG_REMOTE=(google-album-url)
+    make venv
+    make testinitrem
+    make testbuild
+
+At this point the static site should be built and present at
+`output/public/index.html`. You can open this in a browser using `file://` url
+to verify the site looks correct. Or you can serve it on `localhost:8008` with
+`make serve`.
+
+There will also be a link on the generated static site back to the original
+Google photo album.
+
+### OneDrive Photos
+
+At the time of this writing I have not tested OneDrive photos, but it should
+be almost the same as Google Photos.
+
+### AWS S3 Upload
+
+Once a static site album has been generated, either from local files or a
+remote album, it can be uploaded to a third party host. One of the upload
+host options is AWS S3. In order to use this you must have already set up
+AWS S3 for static hosting which is beyond the scope of this section. For a
+little help see [AWS Setup](#aws-setup).
+
+You will need to set up an environment variable with your S3 bucket URL. This
+is your S3 bucket, not the public URL for read access. It looks like
+`s3://some-bucket-name`.
+
+    git switch (branch-being-tested)        # optional as needed
+    cd examples/test_gallery
+    make clean
+    make cleanvenv
+    export SPG_AWS_BUCKET=(aws-bucket-upload-url)
+    make venv
+    make testinit
+    make testbuild
+    make testaws
+
+All the steps prior to `testaws` are the same as [File Gallery](#files-gallery)
+and you can verify the local site in the same way.
+
+The `make testaws` step should upload your site to your AWS bucket. You can
+then view your static site on AWS using your public read URL for your bucket.
+
+### Netlify Upload
+
+At the time of this writing I have not tested with Netlify.
+
+## Test Setups
 
 Running basic init and build from files does not require any special setup.
-But usein AWS or Netlify for uploads, and Google or Onedrive for albums
+But use in AWS or Netlify for uploads, and Google or Onedrive for albums
 requires special setups:
 
-### AWS S3
+### Files Setup
+
+Teting the files-only gallery does not require any setup outside cloning the
+repo and meeting the [test system requirements](#test-system-requirements).
+
+### AWS Setup
 
 SPG supports uploading a gallery to AWS S3 as a static web site.
 This is a brief high-level overview for testing with AWS. It is not a tutorial
@@ -74,24 +230,24 @@ I also had to turn off all the "block public access" settings.
 
 You need to install the aws command line tool and configure it. I did this with
 
-   aws configure
+    aws configure
 
 and used my access key and secret key from my IAM user. After that you can try
 
-   aws s3 ls
+    aws s3 ls
 
 and you should see the name of your bucket
 
 Once I did this, then `gallery-upload aws s3://spg-gallery-test` worked.
 I was able to view the gallery at my bucket private URL.
 
-### Netlify
+### Netlify Setup
 
 SPG supports uploading a gallery to Netlify for a photos web site.
 
 I have not yet got a test working for netlify at the time of this writing.
 
-### Google Photos
+### Google Setup
 
 SPG support building a photo gallery from photos in a google photo album.
 
@@ -99,7 +255,16 @@ To test this simply create a small album in google photos and then get the
 album sharing URL. That URL can then be used for testing SPG gallery-init
 with a google album.
 
-### OneDrive Photos
+### OneDrive Setup
 
 At the time of this writing I have not tested with OneDrive.
+
+## TODOs
+
+* integrate some or all with CI
+* expand expect scripts for something other than default case
+* consider editable mode for venv package install
+* docker image with test environment
+* add tests with different layout configs, ie photos in non-standard location
+* review how much of this could be done by python unit tests instead
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'opencv-python>=4.2.0.32',
         'pillow>=7.0.0',
         'jinja2>=2.10.3',
-        'selenium>=3.141.0',
+        'selenium>=3.141.0,<4.3',
         'requests>=2.22.0',
     ]
 )


### PR DESCRIPTION
This PR deals with a recent selenium problem by just constraining the upper version of selenium. It is a band-aid but allows the remote gallery feature to start working again. Longer term we should consider changing the way geckodriver managed.

This PR also adds to the test gallery README to better explain how to use it for testing.