### PR TITLE
Fix Netlify upload URL

### DIFF
--- a/examples/test_gallery/Makefile
+++ b/examples/test_gallery/Makefile
@@ -124,6 +124,10 @@ testbuild: $(TESTDIR)/public/index.html
 testaws:
 	. venv/bin/activate; cd $(TESTDIR); gallery-upload aws $(SPG_AWS_BUCKET)
 
+.PHONY: testnetlify
+testnetlify:
+	. venv/bin/activate; cd $(TESTDIR); gallery-upload netlify
+
 $(TESTDIR)/public/index.html:
 	. venv/bin/activate; cd $(TESTDIR); gallery-build
 

--- a/simplegallery/upload/variants/netlify_uploader.py
+++ b/simplegallery/upload/variants/netlify_uploader.py
@@ -152,7 +152,7 @@ def deploy_to_netlify(zip_file_path, token, site_id):
 
     response = json.loads(response_string.text)
 
-    return f'https://{response.get("subdomain")}.netlify.com'
+    return response.get("url")
 
 
 def create_website_zip(gallery_path, zip_file_path):


### PR DESCRIPTION
Fixes #143

Redirect and log URL is now taken from the Netlify API response.
Added make command for netlify upload.